### PR TITLE
Update release.yml to use version number instead of hash for autoupdates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,20 @@ jobs:
         asset_path: ./pd2rpd.zip
         asset_name: pd2rpd.zip
         asset_content_type: application/zip
-    - name: Hash mod and create mod meta file
-      id: create_meta_file
+    - name: JSON to variables
+      # see https://github.com/antifree/json-to-variables
+      # You may pin to the exact commit or the version.
+      # uses: antifree/json-to-variables@cc8c6394031e145c90f7f9ec909d83df92431fb8
+      uses: antifree/json-to-variables@v1.0.1
+      with:
+        # The json file.
+        filename: "./Rich Presence Definitive/mod.txt"
+        # The prefix for variables.
+        prefix: "mod"
+    - name: Update version number in meta file
+      id: create_meta_file_v2
       run: |
-         $(cat .\.github\meta.json).Replace("%HASH%", $(./.github/hash.exe "./Rich Presence Definitive").Substring(17)) > ./meta.json
+        $(cat .\.github\meta.json).Replace("%VERSION%", ${{ env.mod_version }}) > ./meta.json
     - name: Upload meta file to Release
       id: upload-meta-asset 
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Instead of using the hash, it now uses the version number (specified in mod.txt) for autoupdating purposes.

This will allow an end-user to update rpd.lua to customize that however they want without the autoupdater to immediately assume that an update is required as a result of the hashes no longer matching (so, when a new update actually is released, they'll know to actually download it)

Encountered the same issue myself when making 'Wow, Rude!' and this is how one fixes this problem.